### PR TITLE
Fixes the Sydney problem*

### DIFF
--- a/modules/handleSpecialNames.js
+++ b/modules/handleSpecialNames.js
@@ -1,0 +1,14 @@
+CITY_TRANSLATIONS = {
+  "sydney" : "sydney-observatory-hill"
+};
+
+function handleSpecialNames(input) {
+  const translation = CITY_TRANSLATIONS[input.toLowerCase()];
+  if (translation) {
+    return translation;
+  } else {
+    return input;
+  }
+}
+
+module.exports = handleSpecialNames;

--- a/modules/processInput.js
+++ b/modules/processInput.js
@@ -1,4 +1,5 @@
 const parseAreas = require('./parseAreas');
+const handleSpecialNames = require('./handleSpecialNames');
 
 function processInput(input) {
   if (input) {
@@ -7,7 +8,7 @@ function processInput(input) {
       const locObj = {
           url: `http://www.bom.gov.au/${loc_data['area']}/observations/${loc_data['mapPage']}.shtml`,
           finder: `#t${loc_data['finder']}`,
-          town: loc_data['town'].replace(' ', '-'),
+          town: handleSpecialNames(input).replace(' ', '-'),
           index: loc_data['index']
       };
       return locObj;

--- a/test/processInput.test.js
+++ b/test/processInput.test.js
@@ -11,6 +11,17 @@ describe('when a valid town is input', () => {
    });
 });
 
+describe('for sydney input', () => {
+   test('returns sydney observatory hill object', () => {
+     expect(processInput('sydney')).toEqual({
+       "finder": "#tSYDNEY",
+       "index": 1,
+       "town": "sydney-observatory-hill",
+       "url": "http://www.bom.gov.au/nsw/observations/sydney.shtml"
+     });
+   })
+});
+
 describe('without an input', () => {
   test('returns an error', () => {
     expect(processInput()).toThrow(TypeError);


### PR DESCRIPTION
Sydney is actually listed as `sydney-observatory-hill` which is annoying since no one's going to ever put that. Problem is, while it'll show you the data, the name's borked. This adds a special translation bit to handle this case. 

I think this is a bit of a patch, and will save Sydney, but isn't going to catch an instance like `Lake Macquarie / Cooranbong` which needs to handle either name. Maybe the secret is to record the index as well for these translations so as to update the index for the name. WHO KNOWS. WHO AM I TYPING TO?

*Creates other problem.